### PR TITLE
Remove "active" and create "open"

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -87,8 +87,7 @@ func (p *Pool) put(pc *PooledConnection) {
 		pc.Client.Close()
 		return
 	}
-	if (pc.Client != nil && pc.Client.Errored) ||
-		(p.MaxLifetime > 0 && time.Now().After(pc.t.Add(p.MaxLifetime))) {
+	if pc.Client != nil && pc.Client.Errored {
 		p.open--
 		pc.Client.Close()
 		return
@@ -199,6 +198,9 @@ func (p *Pool) Close() {
 // returned to the pool for future use.
 func (pc *PooledConnection) Close() {
 	go func() {
+		if pc.Pool.MaxLifetime > 0 && time.Now().After(pc.t.Add(pc.Pool.MaxLifetime)) {
+			pc.Client.Errored = true
+		}
 		pc.Pool.mu.Lock()
 		defer pc.Pool.mu.Unlock()
 

--- a/pool.go
+++ b/pool.go
@@ -66,6 +66,7 @@ func (p *Pool) Get() (*PooledConnection, error) {
 			dc, err := dial()
 			if err != nil {
 				p.mu.Lock()
+				p.open--
 				p.release()
 				p.mu.Unlock()
 				return nil, err
@@ -144,6 +145,7 @@ func (p *Pool) connectionCleaner() {
 			c := p.idle[i]
 			if (ml > 0 && c.pc.t.Before(mlExpiredSince)) ||
 				c.pc.Client.Errored {
+				p.open--
 				closing = append(closing, c)
 				last := len(p.idle) - 1
 				p.idle[i] = p.idle[last]

--- a/pool.go
+++ b/pool.go
@@ -10,6 +10,7 @@ type Pool struct {
 	Dial        func() (*Client, error)
 	MaxActive   int
 	IdleTimeout time.Duration
+	MaxLifetime time.Duration
 	mu          sync.Mutex
 	idle        []*idleConnection
 	active      int
@@ -19,8 +20,9 @@ type Pool struct {
 
 // PooledConnection represents a shared and reusable connection.
 type PooledConnection struct {
-	Pool   *Pool
-	Client *Client
+	Pool      *Pool
+	Client    *Client
+	createdAt time.Time
 }
 
 type idleConnection struct {
@@ -70,7 +72,7 @@ func (p *Pool) Get() (*PooledConnection, error) {
 				return nil, err
 			}
 
-			pc := &PooledConnection{Pool: p, Client: dc}
+			pc := &PooledConnection{Pool: p, Client: dc, createdAt: time.Now()}
 			return pc, nil
 		}
 
@@ -99,7 +101,7 @@ func (p *Pool) put(pc *PooledConnection) {
 // purge removes expired idle connections from the pool.
 // It is not threadsafe. The caller should manage locking the pool.
 func (p *Pool) purge() {
-	if timeout := p.IdleTimeout; timeout > 0 {
+	if p.IdleTimeout > 0 || p.MaxLifetime > 0 {
 		var valid []*idleConnection
 		now := time.Now()
 		for _, v := range p.idle {
@@ -108,12 +110,16 @@ func (p *Pool) purge() {
 				continue
 			}
 
-			if v.t.Add(timeout).After(now) {
-				valid = append(valid, v)
-			} else {
+			if p.IdleTimeout > 0 && v.t.Add(p.IdleTimeout).Before(now) {
 				// Force underlying connection closed
 				v.pc.Client.Close()
+				continue
 			}
+			if p.MaxLifetime > 0 && v.pc.createdAt.Add(p.MaxLifetime).Before(now) {
+				v.pc.Client.Close()
+				continue
+			}
+			valid = append(valid, v)
 		}
 		p.idle = valid
 	}

--- a/pool.go
+++ b/pool.go
@@ -101,7 +101,9 @@ func (p *Pool) put(pc *PooledConnection) {
 // purge removes expired idle connections from the pool.
 // It is not threadsafe. The caller should manage locking the pool.
 func (p *Pool) purge() {
-	if p.IdleTimeout > 0 || p.MaxLifetime > 0 {
+	it := p.IdleTimeout
+	ml := p.MaxLifetime
+	if it > 0 || ml > 0 {
 		var valid []*idleConnection
 		now := time.Now()
 		for _, v := range p.idle {
@@ -110,12 +112,12 @@ func (p *Pool) purge() {
 				continue
 			}
 
-			if p.IdleTimeout > 0 && v.t.Add(p.IdleTimeout).Before(now) {
+			if it > 0 && v.t.Add(it).Before(now) {
 				// Force underlying connection closed
 				v.pc.Client.Close()
 				continue
 			}
-			if p.MaxLifetime > 0 && v.pc.t.Add(p.MaxLifetime).Before(now) {
+			if ml > 0 && v.pc.t.Add(ml).Before(now) {
 				v.pc.Client.Close()
 				continue
 			}

--- a/pool.go
+++ b/pool.go
@@ -198,9 +198,11 @@ func (p *Pool) Close() {
 // Close signals that the caller is finished with the connection and should be
 // returned to the pool for future use.
 func (pc *PooledConnection) Close() {
-	pc.Pool.mu.Lock()
-	defer pc.Pool.mu.Unlock()
+	go func() {
+		pc.Pool.mu.Lock()
+		defer pc.Pool.mu.Unlock()
 
-	pc.Pool.put(pc)
-	pc.Pool.release()
+		pc.Pool.put(pc)
+		pc.Pool.release()
+	}()
 }

--- a/pool.go
+++ b/pool.go
@@ -44,6 +44,9 @@ func (p *Pool) Get() (*PooledConnection, error) {
 		conn := p.first()
 		if conn != nil {
 			// Remove the connection from the idle slice
+			numIdle := len(p.idle)
+			copy(p.idle, p.idle[1:])
+			p.idle = p.idle[:numIdle-1]
 			p.active++
 			p.mu.Unlock()
 			pc := &PooledConnection{Pool: p, Client: conn.pc.Client}

--- a/pool.go
+++ b/pool.go
@@ -20,9 +20,9 @@ type Pool struct {
 
 // PooledConnection represents a shared and reusable connection.
 type PooledConnection struct {
-	Pool      *Pool
-	Client    *Client
-	createdAt time.Time
+	Pool   *Pool
+	Client *Client
+	t      time.Time
 }
 
 type idleConnection struct {
@@ -72,7 +72,7 @@ func (p *Pool) Get() (*PooledConnection, error) {
 				return nil, err
 			}
 
-			pc := &PooledConnection{Pool: p, Client: dc, createdAt: time.Now()}
+			pc := &PooledConnection{Pool: p, Client: dc, t: time.Now()}
 			return pc, nil
 		}
 
@@ -115,7 +115,7 @@ func (p *Pool) purge() {
 				v.pc.Client.Close()
 				continue
 			}
-			if p.MaxLifetime > 0 && v.pc.createdAt.Add(p.MaxLifetime).Before(now) {
+			if p.MaxLifetime > 0 && v.pc.t.Add(p.MaxLifetime).Before(now) {
 				v.pc.Client.Close()
 				continue
 			}

--- a/pool.go
+++ b/pool.go
@@ -15,6 +15,7 @@ type Pool struct {
 	idle        []*idleConnection
 	active      int
 	cond        *sync.Cond
+	cleanerCh   chan struct{}
 	closed      bool
 }
 
@@ -38,25 +39,10 @@ func (p *Pool) Get() (*PooledConnection, error) {
 	// Lock the pool to keep the kids out.
 	p.mu.Lock()
 
-	now := time.Now()
-
 	// Wait loop
 	for {
-		// Try to grab first available idle connection
-		for {
-			conn := p.first()
-			if conn == nil {
-				break
-			}
-			numFree := len(p.idle)
-			copy(p.idle, p.idle[1:])
-			p.idle = p.idle[:numFree-1]
-			if (p.IdleTimeout > 0 && conn.t.Add(p.IdleTimeout).Before(now)) ||
-				(p.MaxLifetime > 0 && conn.pc.t.Add(p.MaxLifetime).Before(now)) {
-				conn.pc.Client.Close()
-				continue
-			}
-
+		conn := p.first()
+		if conn != nil {
 			// Remove the connection from the idle slice
 			p.active++
 			p.mu.Unlock()
@@ -101,38 +87,82 @@ func (p *Pool) put(pc *PooledConnection) {
 		pc.Client.Close()
 		return
 	}
+	if pc.Client != nil && pc.Client.Errored {
+		pc.Client.Close()
+		return
+	}
 	idle := &idleConnection{pc: pc, t: time.Now()}
 	// Prepend the connection to the front of the slice
 	p.idle = append([]*idleConnection{idle}, p.idle...)
-
+	p.startCleanerLocked()
 }
 
-// purge removes expired idle connections from the pool.
-// It is not threadsafe. The caller should manage locking the pool.
-func (p *Pool) purge() {
-	it := p.IdleTimeout
-	ml := p.MaxLifetime
-	if it > 0 || ml > 0 {
-		var valid []*idleConnection
-		now := time.Now()
-		for _, v := range p.idle {
-			// If the client has an error then exclude it from the pool
-			if v.pc.Client.Errored {
-				continue
-			}
+func (p *Pool) needStartCleaner() bool {
+	return (p.MaxLifetime > 0 || p.IdleTimeout > 0) &&
+		len(p.idle) > 0 &&
+		p.cleanerCh == nil
+}
 
-			if it > 0 && v.t.Add(it).Before(now) {
-				// Force underlying connection closed
-				v.pc.Client.Close()
-				continue
-			}
-			if ml > 0 && v.pc.t.Add(ml).Before(now) {
-				v.pc.Client.Close()
-				continue
-			}
-			valid = append(valid, v)
+// startCleanerLocked starts connectionCleaner if needed.
+func (p *Pool) startCleanerLocked() {
+	if p.needStartCleaner() {
+		p.cleanerCh = make(chan struct{}, 1)
+		go p.connectionCleaner()
+	}
+}
+
+func (p *Pool) connectionCleaner() {
+	const minInterval = time.Second
+
+	d := p.MaxLifetime
+	if p.IdleTimeout < p.MaxLifetime {
+		d = p.IdleTimeout
+	}
+	if d < minInterval {
+		d = minInterval
+	}
+	t := time.NewTimer(d)
+
+	for {
+		select {
+		case <-t.C:
+		case <-p.cleanerCh: // dbclient was closed.
 		}
-		p.idle = valid
+
+		ml := p.MaxLifetime
+		it := p.IdleTimeout
+		p.mu.Lock()
+		if p.closed || len(p.idle) == 0 || (ml <= 0 && it <= 0) {
+			p.cleanerCh = nil
+			p.mu.Unlock()
+			return
+		}
+		n := time.Now()
+		mlExpiredSince := n.Add(-ml)
+		itExpiredSince := n.Add(-it)
+		var closing []*idleConnection
+		for i := 0; i < len(p.idle); i++ {
+			c := p.idle[i]
+			if (ml > 0 && c.pc.t.Before(mlExpiredSince)) ||
+				(it > 0 && c.t.Before(itExpiredSince)) ||
+				c.pc.Client.Errored {
+				closing = append(closing, c)
+				last := len(p.idle) - 1
+				p.idle[i] = p.idle[last]
+				p.idle[last] = nil
+				p.idle = p.idle[:last]
+				i--
+			}
+		}
+		p.mu.Unlock()
+
+		for _, c := range closing {
+			if c.pc.Client != nil {
+				c.pc.Client.Close()
+			}
+		}
+
+		t.Reset(d)
 	}
 }
 
@@ -161,6 +191,9 @@ func (p *Pool) Close() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if p.cleanerCh != nil {
+		close(p.cleanerCh)
+	}
 	for _, c := range p.idle {
 		c.pc.Client.Close()
 	}

--- a/pool_test.go
+++ b/pool_test.go
@@ -9,9 +9,9 @@ func TestPurge(t *testing.T) {
 	n := time.Now()
 
 	// invalid has timedout and should be cleaned up
-	invalid := &idleConnection{t: n.Add(-30 * time.Second), pc: &PooledConnection{Client: &Client{}}}
+	invalid := &idleConnection{t: n.Add(-30 * time.Second), pc: &PooledConnection{Client: &Client{}, lifetime: n.Add(defaultMaxLifetime)}}
 	// valid has not yet timed out and should remain in the idle pool
-	valid := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Client: &Client{}}}
+	valid := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Client: &Client{}, lifetime: n.Add(defaultMaxLifetime)}}
 
 	// Pool has a 30 second timeout and an idle connection slice containing both
 	// the invalid and valid idle connections
@@ -38,11 +38,11 @@ func TestPurgeErrorClosedConnection(t *testing.T) {
 
 	p := &Pool{IdleTimeout: time.Second * 30}
 
-	valid := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Client: &Client{}}}
+	valid := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Client: &Client{}, lifetime: n.Add(defaultMaxLifetime)}}
 
 	client := &Client{}
 
-	closed := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Pool: p, Client: client}}
+	closed := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Pool: p, Client: client, lifetime: n.Add(defaultMaxLifetime)}}
 
 	idle := []*idleConnection{valid, closed}
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -9,9 +9,9 @@ func TestPurge(t *testing.T) {
 	n := time.Now()
 
 	// invalid has timedout and should be cleaned up
-	invalid := &idleConnection{t: n.Add(-30 * time.Second), pc: &PooledConnection{Client: &Client{}, lifetime: n.Add(defaultMaxLifetime)}}
+	invalid := &idleConnection{t: n.Add(-30 * time.Second), pc: &PooledConnection{Client: &Client{}}}
 	// valid has not yet timed out and should remain in the idle pool
-	valid := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Client: &Client{}, lifetime: n.Add(defaultMaxLifetime)}}
+	valid := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Client: &Client{}}}
 
 	// Pool has a 30 second timeout and an idle connection slice containing both
 	// the invalid and valid idle connections
@@ -38,11 +38,11 @@ func TestPurgeErrorClosedConnection(t *testing.T) {
 
 	p := &Pool{IdleTimeout: time.Second * 30}
 
-	valid := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Client: &Client{}, lifetime: n.Add(defaultMaxLifetime)}}
+	valid := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Client: &Client{}}}
 
 	client := &Client{}
 
-	closed := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Pool: p, Client: client, lifetime: n.Add(defaultMaxLifetime)}}
+	closed := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Pool: p, Client: client}}
 
 	idle := []*idleConnection{valid, closed}
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -81,7 +81,6 @@ func TestPooledConnectionClose(t *testing.T) {
 	}
 
 	pc.Close()
-	time.Sleep(10 * time.Millisecond)
 
 	if len(pool.idle) != 1 {
 		t.Errorf("Expected 1 idle connection, got %d", len(pool.idle))
@@ -173,7 +172,6 @@ func TestGetAndDial(t *testing.T) {
 
 	// Close the connection and ensure it was returned to the idle pool
 	conn.Close()
-	time.Sleep(time.Millisecond)
 
 	if len(pool.idle) != 1 {
 		t.Error("Expected connection to be returned to idle pool")

--- a/pool_test.go
+++ b/pool_test.go
@@ -166,8 +166,8 @@ func TestGetAndDial(t *testing.T) {
 		t.Error("Expected correct client to be returned")
 	}
 
-	if pool.open != 1 {
-		t.Errorf("Expected 1 opened connection, got %d", pool.open)
+	if pool.open != 0 {
+		t.Errorf("Expected 0 opened connection, got %d", pool.open)
 	}
 
 	// Close the connection and ensure it was returned to the idle pool
@@ -175,10 +175,6 @@ func TestGetAndDial(t *testing.T) {
 
 	if len(pool.idle) != 1 {
 		t.Error("Expected connection to be returned to idle pool")
-	}
-
-	if pool.open != 1 {
-		t.Errorf("Expected 1 opened connections, got %d", pool.open)
 	}
 
 	// Get a new connection and ensure that it is the now idling connection
@@ -190,9 +186,5 @@ func TestGetAndDial(t *testing.T) {
 
 	if conn.Client != client {
 		t.Error("Expected the same connection to be reused")
-	}
-
-	if pool.open != 1 {
-		t.Errorf("Expected 1 opened connection, got %d", pool.open)
 	}
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -81,6 +81,7 @@ func TestPooledConnectionClose(t *testing.T) {
 	}
 
 	pc.Close()
+	time.Sleep(10 * time.Millisecond)
 
 	if len(pool.idle) != 1 {
 		t.Errorf("Expected 1 idle connection, got %d", len(pool.idle))
@@ -172,6 +173,7 @@ func TestGetAndDial(t *testing.T) {
 
 	// Close the connection and ensure it was returned to the idle pool
 	conn.Close()
+	time.Sleep(time.Millisecond)
 
 	if len(pool.idle) != 1 {
 		t.Error("Expected connection to be returned to idle pool")

--- a/pool_test.go
+++ b/pool_test.go
@@ -9,13 +9,13 @@ func TestConnectionCleaner(t *testing.T) {
 	n := time.Now()
 
 	// invalid has timedout and should be cleaned up
-	invalid := &idleConnection{t: n.Add(-30 * time.Second), pc: &PooledConnection{Client: &Client{}, t: n}}
+	invalid := &idleConnection{pc: &PooledConnection{Client: &Client{}, t: n.Add(-1030 * time.Millisecond)}}
 	// valid has not yet timed out and should remain in the idle pool
-	valid := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Client: &Client{}, t: n}}
+	valid := &idleConnection{pc: &PooledConnection{Client: &Client{}, t: n.Add(1030 * time.Millisecond)}}
 
 	// Pool has a 30 second timeout and an idle connection slice containing both
 	// the invalid and valid idle connections
-	p := &Pool{IdleTimeout: time.Second * 31, idle: []*idleConnection{invalid, valid}}
+	p := &Pool{MaxLifetime: time.Second * 1, idle: []*idleConnection{invalid, valid}}
 
 	if len(p.idle) != 2 {
 		t.Errorf("Expected 2 idle connections, got %d", len(p.idle))
@@ -27,10 +27,10 @@ func TestConnectionCleaner(t *testing.T) {
 
 	time.Sleep(1010 * time.Millisecond)
 	if len(p.idle) != 1 {
-		t.Errorf("Expected 1 idle connection after purge, got %d", len(p.idle))
+		t.Errorf("Expected 1 idle connection after clean, got %d", len(p.idle))
 	}
 
-	if p.idle[0].t != valid.t {
+	if p.idle[0].pc.t != valid.pc.t {
 		t.Error("Expected the valid connection to remain in idle pool")
 	}
 
@@ -39,13 +39,13 @@ func TestConnectionCleaner(t *testing.T) {
 func TestPurgeErrorClosedConnection(t *testing.T) {
 	n := time.Now()
 
-	p := &Pool{IdleTimeout: time.Second * 30}
+	p := &Pool{MaxLifetime: time.Second * 1}
 
-	valid := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Client: &Client{}, t: n}}
+	valid := &idleConnection{pc: &PooledConnection{Client: &Client{}, t: n.Add(1030 * time.Millisecond)}}
 
 	client := &Client{}
 
-	closed := &idleConnection{t: n.Add(30 * time.Second), pc: &PooledConnection{Pool: p, Client: client, t: n}}
+	closed := &idleConnection{pc: &PooledConnection{Pool: p, Client: client, t: n.Add(1030 * time.Millisecond)}}
 
 	idle := []*idleConnection{valid, closed}
 
@@ -64,7 +64,7 @@ func TestPurgeErrorClosedConnection(t *testing.T) {
 	time.Sleep(1010 * time.Millisecond)
 
 	if len(p.idle) != 1 {
-		t.Errorf("Expected 1 idle connection after purge, got %d", len(p.idle))
+		t.Errorf("Expected 1 idle connection after clean, got %d", len(p.idle))
 	}
 
 	if p.idle[0] != valid {
@@ -91,19 +91,15 @@ func TestPooledConnectionClose(t *testing.T) {
 	if idled == nil {
 		t.Error("Expected to get connection")
 	}
-
-	if idled.t.IsZero() {
-		t.Error("Expected an idled time")
-	}
 }
 
 func TestFirst(t *testing.T) {
 	n := time.Now()
-	pool := &Pool{MaxActive: 1, IdleTimeout: 30 * time.Second}
+	pool := &Pool{MaxOpen: 1, MaxLifetime: 30 * time.Millisecond}
 	idled := []*idleConnection{
-		&idleConnection{t: n.Add(-45 * time.Second), pc: &PooledConnection{Pool: pool, Client: &Client{}}}, // expired
-		&idleConnection{t: n.Add(-45 * time.Second), pc: &PooledConnection{Pool: pool, Client: &Client{}}}, // expired
-		&idleConnection{pc: &PooledConnection{Pool: pool, Client: &Client{}}},                              // valid
+		&idleConnection{pc: &PooledConnection{Pool: pool, Client: &Client{}, t: n.Add(-45 * time.Millisecond)}}, // expired
+		&idleConnection{pc: &PooledConnection{Pool: pool, Client: &Client{}, t: n.Add(-45 * time.Millisecond)}}, // expired
+		&idleConnection{pc: &PooledConnection{Pool: pool, Client: &Client{}}},                                   // valid
 	}
 	pool.idle = idled
 
@@ -111,7 +107,7 @@ func TestFirst(t *testing.T) {
 		t.Errorf("Expected 3 idle connection, got %d", len(pool.idle))
 	}
 
-	// Get should return the last idle connection and purge the others
+	// Get should return the last idle connection and clean the others
 	c := pool.first()
 
 	if c != pool.idle[0] {
@@ -131,9 +127,9 @@ func TestFirst(t *testing.T) {
 func TestGetAndDial(t *testing.T) {
 	n := time.Now()
 
-	pool := &Pool{IdleTimeout: time.Second * 30}
+	pool := &Pool{MaxLifetime: time.Millisecond * 30}
 
-	invalid := &idleConnection{t: n.Add(-30 * time.Second), pc: &PooledConnection{Pool: pool, Client: &Client{}, t: n}}
+	invalid := &idleConnection{pc: &PooledConnection{Pool: pool, Client: &Client{}, t: n.Add(-30 * time.Millisecond)}}
 
 	idle := []*idleConnection{invalid}
 	pool.idle = idle
@@ -170,8 +166,8 @@ func TestGetAndDial(t *testing.T) {
 		t.Error("Expected correct client to be returned")
 	}
 
-	if pool.active != 1 {
-		t.Errorf("Expected 1 active connection, got %d", pool.active)
+	if pool.open != 1 {
+		t.Errorf("Expected 1 opened connection, got %d", pool.open)
 	}
 
 	// Close the connection and ensure it was returned to the idle pool
@@ -181,8 +177,8 @@ func TestGetAndDial(t *testing.T) {
 		t.Error("Expected connection to be returned to idle pool")
 	}
 
-	if pool.active != 0 {
-		t.Errorf("Expected 0 active connections, got %d", pool.active)
+	if pool.open != 1 {
+		t.Errorf("Expected 1 opened connections, got %d", pool.open)
 	}
 
 	// Get a new connection and ensure that it is the now idling connection
@@ -196,7 +192,7 @@ func TestGetAndDial(t *testing.T) {
 		t.Error("Expected the same connection to be reused")
 	}
 
-	if pool.active != 1 {
-		t.Errorf("Expected 1 active connection, got %d", pool.active)
+	if pool.open != 1 {
+		t.Errorf("Expected 1 opened connection, got %d", pool.open)
 	}
 }


### PR DESCRIPTION
Hi @schwartzmx !
Thank you very much for [merge my contribute](https://github.com/schwartzmx/gremgo-neptune/pull/2) before. I use your library `gremgo-neptune` forked [jumpeiMano/gremgo-neptune](https://github.com/jumpeiMano/gremgo-neptune).

I tryed to change Pool.
- Remove `max_active`, `active` and `IdleTimeout`
- Add `max_open`, `open` and `MaxLifetime`
Because of neptune cluster's `bias`. When connecting to the cluster endpoint of neptune, it happens that connections are biased towards a specific replica. In order to rectify that bias, we forced the connection created forcibly by max lifetime to close so that bias is corrected.<br>
- Add connection cleaner
Before the connection's timeout check is running in Get() every time, but I think it pays high costs.

Since this pull request is not backward compatible, you may find it difficult to merge this. Thank you for your consideration.